### PR TITLE
Added dummy files to fix Travis-CI failures

### DIFF
--- a/tests/Propel/Tests/Silex/PropelFixtures/FixtEmpty/build/classes/classes.txt
+++ b/tests/Propel/Tests/Silex/PropelFixtures/FixtEmpty/build/classes/classes.txt
@@ -1,0 +1,1 @@
+This file has been added because git doesn't allow push of empty directories

--- a/tests/Propel/Tests/Silex/PropelFixtures/FixtEmpty/build/conf/conf.txt
+++ b/tests/Propel/Tests/Silex/PropelFixtures/FixtEmpty/build/conf/conf.txt
@@ -1,0 +1,1 @@
+This file has been added because git doesn't allow push of empty directories

--- a/tests/Propel/Tests/Silex/PropelFixtures/FixtFull/build/classes/mynamespace/mynamespace.txt
+++ b/tests/Propel/Tests/Silex/PropelFixtures/FixtFull/build/classes/mynamespace/mynamespace.txt
@@ -1,0 +1,1 @@
+This file has been added because git doesn't allow push of empty directories


### PR DESCRIPTION
The test suite expected to work on 4 fixtures dirs. But 3 of those dirs were empty so Git didn't push them on my Github master branch. So, on Travis-ci the tests have failed.
In this PR we add 3 dummy files, to push correctly the fixtures dirs.
