### PR TITLE
Update according to new Silex version (see issue #7)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 vendor
 composer.lock
+composer.phar

--- a/README.md
+++ b/README.md
@@ -19,10 +19,6 @@ Parameters
 * **propel.model_path** (optional): Path to where model classes are located.
   Default is `/full/project/path/build/classes`
 
-* **propel.internal_autoload** (optional): Setting to true, forces Propel to use
-  its own internal autoloader, instead of Silex one, to load model classes.
-  Default is `false`
-
 
 > It's strongly recommanded to use **absolute paths** for previous options.
 
@@ -45,10 +41,6 @@ For more informations consult the [Propel documentation](http://www.propelorm.or
 
 ``` php
 <?php
-
-$app['autoloader']->registerNamespaces(array(
-    'Propel\Silex'  => __DIR__ . '/../../vendor/propel/propel-service-provider/src',
-));
 
 $app->register(new Propel\Silex\PropelServiceProvider(), array(
     'propel.path'        => __DIR__.'/path/to/Propel.php',

--- a/tests/Propel/Tests/Silex/PropelServiceProviderTest.php
+++ b/tests/Propel/Tests/Silex/PropelServiceProviderTest.php
@@ -36,8 +36,8 @@ class PropelServiceProviderTest extends \PHPUnit_Framework_TestCase
             'propel.model_path'     => __DIR__ . '/PropelFixtures/FixtFull/build/classes',
         ));
 
-        $this->assertTrue(class_exists('Propel'));
-
+        $this->assertTrue(class_exists('Propel'), 'Propel class does not exist.');
+        $this->assertGreaterThan(strpos(get_include_path(), $app['propel.model_path']), 1);
     }
 
     public function testRegisterDefaults()
@@ -50,28 +50,15 @@ class PropelServiceProviderTest extends \PHPUnit_Framework_TestCase
             'propel.path'           => __DIR__ . '/../../../../vendor/propel/propel1/runtime/lib',
         ));
 
-        $this->assertTrue(class_exists('Propel'));
+        $this->assertTrue(class_exists('Propel'), 'Propel class does not exist.');
+        $this->assertGreaterThan(strpos(get_include_path(), './build/classes'), 1);
 
         chdir($current);
     }
 
-    public function testRegisterInternalAutoload()
-    {
-        $app = new Application();
-        $app->register(new PropelServiceProvider(), array(
-            'propel.path'               => __DIR__.'/../../../../vendor/propel/propel1/runtime/lib',
-            'propel.config_file'        => __DIR__.'/PropelFixtures/FixtFull/build/conf/myproject-conf.php',
-            'propel.model_path'         => __DIR__.'/PropelFixtures/FixtFull/build/classes',
-            'propel.internal_autoload'  => true,
-        ));
-
-        $this->assertTrue(class_exists('Propel'), 'Propel class does not exist.');
-        $this->assertGreaterThan(strpos(get_include_path(), $app['propel.model_path']), 1);
-    }
-
     /**
      * @expectedException  InvalidArgumentException
-     * @expectedExceptionMessage  Please, initialize the "propel.config_file" parameter.
+     * @expectedExceptionMessage  Unable to guess the config file. Please, initialize the "propel.config_file" parameter.
      */
     public function testConfigFilePropertyNotInitialized()
     {
@@ -106,14 +93,15 @@ class PropelServiceProviderTest extends \PHPUnit_Framework_TestCase
 
     /**
      * @expectedException  InvalidArgumentException
+     * @expectedExceptionMessage  The given "propel.model_path" is not found.
      */
-    public function testNoNamespace()
+    public function testWrongModelPath()
     {
         $app = new Application();
         $app->register(new PropelServiceProvider(), array(
-            'propel.path'               => __DIR__.'/../../../../vendor/propel/propel1/runtime/lib',
-            'propel.model_path'         => __DIR__.'/PropelFixtures/FixtEmpty/build/classes',
-            'propel.config_file'        => __DIR__.'/PropelFixtures/FixtFull/build/conf/myproject-conf.php',
+            'propel.path'           => __DIR__ . '/../../../../vendor/propel/propel1/runtime/lib',
+            'propel.config_file'    => __DIR__ . '/PropelFixtures/FixtFull/build/conf/myproject-conf.php',
+            'propel.model_path'     => __DIR__ . '/wrongDir/build/classes',
         ));
     }
 

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -1,6 +1,6 @@
 <?php
 
-$loader = require_once __DIR__.'/../vendor/.composer/autoload.php';
+$loader = require_once __DIR__.'/../vendor/autoload.php';
 $loader->register('Propel', __DIR__.'/../src');
 
 require_once __DIR__.'/../vendor/propel/propel1/runtime/lib/Propel.php';


### PR DESCRIPTION
New Silex version breaks some backward-compatibilities (http://silex.sensiolabs.org/doc/changelog.html), in particular it switches from Symfony ClassLoader component to Composer class loader.

We've refactored PropelServiceProvider to always use Propel internal autoload, to load model classes, so  now it's compatible with every Silex version.
