### PR TITLE
Allow the use of Propel before Silex boots

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,11 +42,9 @@ For more informations consult the [Propel documentation](http://www.propelorm.or
 ``` php
 <?php
 
-$app->register(new Propel\Silex\PropelServiceProvider(), array(
-    'propel.path'        => __DIR__.'/path/to/Propel.php',
-    'propel.config_file' => __DIR__.'/path/to/myproject-conf.php',
-    'propel.model_path'  => __DIR__.'/path/to/model/classes',
-));
+$app['propel.config_file'] = __DIR__.'/path/to/myproject-conf.php';
+$app['propel.model_path'] = __DIR__.'/path/to/model/classes';
+$app->register(new Propel\Silex\PropelServiceProvider());
 ```
 
 Alternatively, if you 've installed Propel by Git in `vendor/propel` and

--- a/composer.json
+++ b/composer.json
@@ -18,6 +18,7 @@
         "silex/silex": "1.0.*",
         "propel/propel1": "1.6.*"
     },
+    "minimum-stability": "dev",
     "autoload": {
         "psr-0": { "Propel\\Silex": "src" }
     }

--- a/src/Propel/Silex/PropelServiceProvider.php
+++ b/src/Propel/Silex/PropelServiceProvider.php
@@ -20,11 +20,23 @@ use Silex\ServiceProviderInterface;
  */
 class PropelServiceProvider implements ServiceProviderInterface
 {
+    protected $alreadyInit = false;
+
     public function register(Application $app)
     {
+        if (isset($app['propel.model_path']) && isset($app['propel.config_file'])) {
+            $this->initPropel($app);
+        }
     }
 
     public function boot(Application $app)
+    {
+        if (!$this->alreadyInit) {
+            $this->initPropel($app);
+        }
+    }
+
+    protected function initPropel(Application $app)
     {
         if (!class_exists('Propel')) {
             require_once $this->guessPropel($app);
@@ -35,6 +47,8 @@ class PropelServiceProvider implements ServiceProviderInterface
 
         \Propel::init($config);
         set_include_path($modelPath . PATH_SEPARATOR . get_include_path());
+
+        $this->alreadyInit = true;
     }
 
     protected  function guessPropel(Application $app)


### PR DESCRIPTION
As it is, it isn't possible to use Propel before Silex boots, which means it's not available during the bootstrap process aswell as when executing asserts (which was our problem originally).

``` php
<?php

$app->get('/{slug}', array($this, 'function'))
    ->assert('slug', SlugPeer::assertUrl()) // assertUrl returns the list of authorized slugs separated by |
;
```
