### PR TITLE
Depend on the last Propel release instead of master

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,7 @@
     ],
     "require": {
         "silex/silex": "~1.0",
-        "propel/propel": "dev-master"
+        "propel/propel": "2.0.0-alpha2"
     },
     "require-dev": {
         "phpunit/phpunit": "3.7.*"


### PR DESCRIPTION
Hello,

If we are testing the alpha, we can't install the service provider because it requires Propel in the dev-master version. Let me know if anything is wrong ; I will happily update my patch.

Have a nice day.
