### PR TITLE
Compatible with Propel2 master branch

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,7 @@
     ],
     "require": {
         "silex/silex": "~1.0",
-        "propel/propel": "2.0.0-alpha2"
+        "propel/propel": "~2.0@dev"
     },
     "require-dev": {
         "phpunit/phpunit": "3.7.*"


### PR DESCRIPTION
I want to use the service provider together with the master branch of Propel2. So my composer.json looks like:

``` json
{
    "require": {
        "propel/propel-service-provider": "~2.0@dev",
        "propel/propel": "~2.0@dev"
    }
}
```

But I get the 2.0.0-alpha2 because the service provider sets this as min version, and alpha2 is greater than dev. With this change I will get the dev branches of both repos when using the given composer.json.
